### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,9 +1,18 @@
-on: [push]
+name: Deploy to GitHub Pages
+
+on:
+  push:
+
+permissions:
+  contents: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,11 @@
+on: [push]
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: .
+


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to automatically publish repository contents to GitHub Pages using `peaceiris/actions-gh-pages@v4`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e27e2b8ec832993ec42923806cfb8